### PR TITLE
Fix Railway buttons; CI install tweak; deploy services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
           cache: 'npm'
 
       - name: Install deps
-        run: npm ci --no-audit --no-fund
+        run: |
+          if [ -f package-lock.json ]; then npm ci; else npm i; fi
 
       - name: Typecheck
         run: npm run typecheck

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Production-ready deployment on Railway.
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template?template=https://github.com/yosiwizman/OfficeMate&plugins=postgresql)
+[![Deploy UI on Railway](https://railway.app/button.svg)](https://railway.app/template/new?templateUrl=https%3A%2F%2Fgithub.com%2Fyosiwizman%2FOfficeMate)
+
+[![Deploy Desktop on Railway](https://railway.app/button.svg)](https://railway.app/template/new?templateUrl=https%3A%2F%2Fgithub.com%2Fyosiwizman%2FOfficeMate&rootDir=services%2Fdesktop)
 
 ## Services
 - UI (this repo root, Next.js)
@@ -38,13 +40,19 @@ npm i
 npm run dev
 ```
 
+## How to deploy (buttons or CLI)
+
+- One-click deploys:
+  - UI (root): https://railway.app/template/new?templateUrl=https%3A%2F%2Fgithub.com%2Fyosiwizman%2FOfficeMate
+  - Desktop (services/desktop): https://railway.app/template/new?templateUrl=https%3A%2F%2Fgithub.com%2Fyosiwizman%2FOfficeMate&rootDir=services%2Fdesktop
+
 ## Deploy via Railway CLI
 
 ```bash
 # login (headless: copy the code into the browser once prompted)
 railway login --browserless
 # link to project
-railway link --project fe6153db-0ea2-48da-a0c3-08de4ef33abc
+railway link --project 22dac265-ded4-4ece-9d74-66e847077195
 
 # create UI variables (placeholders)
 railway variables set \
@@ -61,10 +69,12 @@ railway up --service "UI" --detach --verbose
 
 # create Desktop service env
 cd services/desktop
-railway variables set PORT=3000 TZ=UTC PUID=1000 PGID=1000 PASSWORD=change-me
+railway variables set PORT=3000 TZ=UTC PUID=1000 PGID=1000 PASSWORD=ChangeMe-Strong!
 
 # deploy Desktop
 railway up --service "Desktop" --detach --verbose
 ```
+
+First run: Desktop may prompt for a password in the iframe; use the PASSWORD env you set.
 
 After Desktop deploy, copy its public URL and paste into the UI service variable NEXT_PUBLIC_DESKTOP_URL.


### PR DESCRIPTION
This PR fixes the README deploy buttons (UI + Desktop), adds a CI install fallback, and prepares for Railway deploys.\n\n- README: two buttons with correct templateUrl + rootDir\n- CI: if lockfile missing, use npm i (while keeping npm ci fast path)\n- No secrets committed\n\nFollow-up in this run will deploy Desktop and UI to Railway project 22dac265-ded4-4ece-9d74-66e847077195 and return smoke outputs.